### PR TITLE
Add Tor proxy support

### DIFF
--- a/bus/infrastructure.go
+++ b/bus/infrastructure.go
@@ -85,7 +85,7 @@ type descriptor struct {
 }
 
 // New initializes a Bus struct that embeds a btcd RPC client.
-func New(host string, user string, pass string, noTLS bool) (*Bus, error) {
+func New(host string, user string, pass string, proxy string, noTLS bool) (*Bus, error) {
 	log.Info("Warming up...")
 
 	// Prepare the connection config to initialize the rpcclient.Client
@@ -94,6 +94,7 @@ func New(host string, user string, pass string, noTLS bool) (*Bus, error) {
 		Host:         fmt.Sprintf("%s/wallet/%s", host, walletName),
 		User:         user,
 		Pass:         pass,
+		Proxy:        proxy,
 		HTTPPostMode: true,
 		DisableTLS:   noTLS,
 	}

--- a/cmd/lss.go
+++ b/cmd/lss.go
@@ -44,6 +44,7 @@ func startup() *svc.Service {
 		*configuration.RPCURL,
 		*configuration.RPCUser,
 		*configuration.RPCPassword,
+		*configuration.TorProxy,
 		configuration.NoTLS,
 	)
 	if err != nil {

--- a/cmd/lss.go
+++ b/cmd/lss.go
@@ -44,7 +44,7 @@ func startup() *svc.Service {
 		*configuration.RPCURL,
 		*configuration.RPCUser,
 		*configuration.RPCPassword,
-		*configuration.TorProxy,
+		configuration.TorProxy,
 		configuration.NoTLS,
 	)
 	if err != nil {

--- a/config/models.go
+++ b/config/models.go
@@ -23,6 +23,7 @@ type Configuration struct {
 	RPCURL      *string   `json:"rpcurl"`
 	RPCUser     *string   `json:"rpcuser"`
 	RPCPassword *string   `json:"rpcpass"`
+	TorProxy    *string   `json:"torproxy"`
 	NoTLS       bool      `json:"notls"`
 	Accounts    []Account `json:"accounts"`
 }

--- a/config/models.go
+++ b/config/models.go
@@ -23,7 +23,7 @@ type Configuration struct {
 	RPCURL      *string   `json:"rpcurl"`
 	RPCUser     *string   `json:"rpcuser"`
 	RPCPassword *string   `json:"rpcpass"`
-	TorProxy    *string   `json:"torproxy"`
+	TorProxy    string    `json:"torproxy"`
 	NoTLS       bool      `json:"notls"`
 	Accounts    []Account `json:"accounts"`
 }


### PR DESCRIPTION
This PR uses the `Proxy` option of `bcd/rpcclient` to support Tor. 

`torproxy` can be set in `lss.json`. If a tor proxy is set, LSS will be able to establish a connection with an onion url, set in `rpcurl`.

Example of `lss.json`:
```
{
    "accounts": [...],
    "rpcurl": "abcdefghijklmno.onion:8332",
    "rpcuser": "umbrel",
    "rpcpass": "password",
    "torproxy": "socks5://127.0.0.1:9050",
    "notls": true
}
```