### PR TITLE
iterateints has been removed from the construct python library: Force version of construct in scripts/requirements.txt as a workaround

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
 base58
 click
-construct
+construct==2.10.61
 ecdsa
 ledgerwallet
 protobuf


### PR DESCRIPTION
Recent release of construct library, version 2.10.63, causes ledgerwallet library and `scripts/getdescriptor` to fail due to removal of iterateints. Force version of construct to 2.10.61 in `scripts/requirements.txt` as a workaround.

See https://github.com/LedgerHQ/satstack/issues/50 and https://github.com/LedgerHQ/ledgerctl/issues/17
