### PR TITLE
README.md: clarify use of environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ and import your accounts. This can take a while.
 #### Launch Ledger Live Desktop
 
 ```sh
-$ EXPLORER=http://0.0.0.0:20000 <Ledger Live executable>
+# environment variable `EXPLORER_SATSTACK` should point at the address
+# where `lss` is listening (can be a differnet computer/server)
+$ EXPLORER_SATSTACK=http://127.0.0.1:20000 <Ledger Live executable>
 ```
 
 ## In the press


### PR DESCRIPTION
Explain how to set the ledger-live-common `EXPLORER_SATSTACK`
environment variable and remove the previously mentioned `EXPLORER`
variable (which affects all chains, not just Bitcoin, and thus makes
other chains misbehave in Ledger Live).

See: https://github.com/LedgerHQ/ledger-live-common/blob/f92468f1c81b2681acd67d075d74e6874d56f434/src/env.ts#L288-L292
