### PR TITLE
Improve speed when importing descriptors (startup time) and some smaller changes

### DIFF
--- a/bus/infrastructure.go
+++ b/bus/infrastructure.go
@@ -37,8 +37,10 @@ const (
 	// bitcoind's wallet.
 	walletName = "satstack"
 
-	errDuplicateWalletLoadMsg = "Duplicate -wallet filename specified."
-	errWalletAlreadyLoadedMsg = "Wallet file verification failed. Refusing to load database. Data file"
+	errDuplicateWalletLoadMsg    = "Duplicate -wallet filename specified."
+	errWalletAlreadyLoadedMsgOld = "Wallet file verification failed. Refusing to load database. Data file"
+	// Cores Responds changes so adding the new one but keeping the old for backwards compatibility
+	errWalletAlreadyLoadedMsgNew = "Wallet file verification failed. SQLiteDatabase: Unable to obtain an exclusive lock on the database"
 )
 
 // Bus represents a transport allowing access to Bitcoin RPC methods.
@@ -303,7 +305,12 @@ func loadOrCreateWallet(client *rpcclient.Client) (bool, error) {
 		return false, nil
 	}
 
-	if rpcErr.Code == btcjson.ErrRPCWallet && strings.Contains(rpcErr.Message, errWalletAlreadyLoadedMsg) {
+	if rpcErr.Code == btcjson.ErrRPCWallet && strings.Contains(rpcErr.Message, errWalletAlreadyLoadedMsgOld) {
+		// wallet already loaded. Ignore the error and return.
+		return false, nil
+	}
+
+	if rpcErr.Code == btcjson.ErrRPCWallet && strings.Contains(rpcErr.Message, errWalletAlreadyLoadedMsgNew) {
 		// wallet already loaded. Ignore the error and return.
 		return false, nil
 	}

--- a/bus/wallet.go
+++ b/bus/wallet.go
@@ -118,7 +118,7 @@ func ImportDescriptors(client *rpcclient.Client, descriptors []descriptor) error
 	var hasError bool
 
 	fields := log.WithFields(log.Fields{
-		"NumofDescriptor": len(requestDescriptors),
+		"NumofDescriptors": len(requestDescriptors),
 	})
 
 	if !importDescriptorResult[0].Success {

--- a/bus/wallet.go
+++ b/bus/wallet.go
@@ -47,7 +47,7 @@ func (b *Bus) GetTransactionHex(hash *chainhash.Hash) (string, error) {
 	return tx.Hex, nil
 }
 
-//see https://developer.bitcoin.org/reference/rpc/importdescriptors.html for specs
+// see https://developer.bitcoin.org/reference/rpc/importdescriptors.html for specs
 type ImportDesciptorRequest struct {
 	Descriptor string `json:"desc"`                 //(string, required) Descriptor to import.
 	Active     bool   `json:"active,omitempty"`     //(boolean, optional, default=false) Set this descriptor to be the active descriptor for the corresponding output type/externality
@@ -70,61 +70,67 @@ type ImportDescriptorResult struct {
 
 func ImportDescriptors(client *rpcclient.Client, descriptors []descriptor) error {
 
+	// We are going to import all descriptors together which saves us a lot of time
+
+	var requestDescriptors []ImportDesciptorRequest
+	var params []json.RawMessage
+
 	for _, descriptor := range descriptors {
 
-		// only 1 request per descriptor
-		var requests = new([1]ImportDesciptorRequest)
-		var params []json.RawMessage
-
-		requests[0] = ImportDesciptorRequest{
+		requests := ImportDesciptorRequest{
 			Descriptor: descriptor.Value,
+			Active:     true,
 			Range:      []int{0, descriptor.Depth},
 			Timestamp:  descriptor.Age,
 		}
 
-		myIn, mErr := json.Marshal(requests)
+		requestDescriptors = append(requestDescriptors, requests)
 
-		if mErr != nil {
-			log.Error(`mErr`, mErr)
-			return mErr
-		}
+	}
 
-		myInRaw := json.RawMessage(myIn)
-		params = append(params, myInRaw)
+	myIn, mErr := json.Marshal(requestDescriptors)
 
-		method := "importdescriptors"
+	if mErr != nil {
+		log.Error(`mErr`, mErr)
+		return mErr
+	}
 
-		result, err := client.RawRequest(method, params)
+	myInRaw := json.RawMessage(myIn)
+	params = append(params, myInRaw)
 
-		if err != nil {
-			log.Error(`err `, err)
-			return err
-		}
+	method := "importdescriptors"
 
-		var importDescriptorResult []ImportDescriptorResult
-		umerr := json.Unmarshal(result, &importDescriptorResult)
+	result, err := client.RawRequest(method, params)
 
-		if umerr != nil {
-			log.Error(`umerr `, umerr)
-			return umerr
-		}
+	if err != nil {
+		log.Error(`err `, err)
+		return err
+	}
 
-		var hasError bool
+	var importDescriptorResult []ImportDescriptorResult
+	umerr := json.Unmarshal(result, &importDescriptorResult)
 
-		fields := log.WithFields(log.Fields{
-			"descriptor": descriptor.Value,
-		})
+	if umerr != nil {
+		log.Error(`umerr `, umerr)
+		return umerr
+	}
 
-		if importDescriptorResult[0].Success == false {
-			fields.Error("ImportDescriptors - Failed to import descriptor" + " || " + importDescriptorResult[0].Error.Message + importDescriptorResult[0].Error.Error())
-			hasError = true
-		} else {
-			fields.Debug("ImportDescriptors - Import descriptor successfully")
-		}
+	var hasError bool
 
-		if hasError {
-			return fmt.Errorf("ImportDescriptors - importdescriptor RPC failed")
-		}
+	fields := log.WithFields(log.Fields{
+		"NumofDescriptor": len(requestDescriptors),
+	})
+
+	if !importDescriptorResult[0].Success {
+
+		fields.Error("ImportDescriptors - Failed to import descriptor" + " || " + importDescriptorResult[0].Error.Error())
+		hasError = true
+	} else {
+		fields.Debug("ImportDescriptors - Import descriptor successfully")
+	}
+
+	if hasError {
+		return fmt.Errorf("ImportDescriptors - importdescriptor RPC failed")
 	}
 
 	return nil

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -21,6 +21,8 @@ import (
 func init() {
 	rootCmd.PersistentFlags().String("port", "20000", "Port")
 	rootCmd.PersistentFlags().Bool("unload-wallet", false, "whether SatStack should unload wallet")
+	rootCmd.PersistentFlags().Bool("skip-circulation-check", false, "skip the circulation check")
+
 }
 
 var rootCmd = &cobra.Command{
@@ -30,8 +32,9 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		port, _ := cmd.Flags().GetString("port")
 		unloadWallet, _ := cmd.Flags().GetBool("unload-wallet")
+		skipCirculationCheck, _ := cmd.Flags().GetBool("skip-circulation-check")
 
-		s := startup(unloadWallet)
+		s := startup(unloadWallet, skipCirculationCheck)
 		if s == nil {
 			return
 		}
@@ -93,7 +96,7 @@ func Execute() {
 	}
 }
 
-func startup(unloadWallet bool) *svc.Service {
+func startup(unloadWallet bool, skipCirculationCheck bool) *svc.Service {
 
 	// log.SetLevel(logrus.DebugLevel)
 
@@ -147,7 +150,7 @@ func startup(unloadWallet bool) *svc.Service {
 
 	fortunes.Fortune()
 
-	s.Bus.Worker(configuration)
+	s.Bus.Worker(configuration, skipCirculationCheck)
 
 	return s
 }

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -98,7 +98,9 @@ func Execute() {
 
 func startup(unloadWallet bool, skipCirculationCheck bool) *svc.Service {
 
-	// log.SetLevel(logrus.DebugLevel)
+	if version.Build == "development" {
+		log.SetLevel(log.DebugLevel)
+	}
 
 	log.SetFormatter(&prefixed.TextFormatter{
 		TimestampFormat:  "2006/01/02 - 15:04:05",

--- a/magefile.go
+++ b/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main
@@ -63,7 +64,7 @@ func flagEnv() map[string]string {
 	}
 
 	return map[string]string{
-		"PACKAGE":     "satstack",
+		"PACKAGE":     "github.com/ledgerhq/satstack",
 		"COMMIT_HASH": hash,
 		"BUILD":       build,
 	}


### PR DESCRIPTION
This PR is the first one of my journey improving this tool, to make it more useable and finally integrating it to the raspiblitz. This PR makes 3 things which are separated by their own commits, making them easy to review and getting them merged hopefully fast.


1. It changes the importing scheme of the descriptors. The old logic was to import every descriptor separately which leads to several rescan along the way. Doing this in one move lets us only load the descriptor once making the rescan time unrelated to the amount of descriptors which are loaded in

2. It adds a new Load wallet failure message which was maybe introduced along the way also catching an error where the wallet is already loaded and we do not recognize it.

3. Third thing is a small cli flag to skip the circulation check, makes testing faster because it takes to long for testing it makes life easier.


This fixes several issues one of them is #77 